### PR TITLE
MoveIt Task Constructor Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.15)
 project(bio_ik)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -6,17 +6,16 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS
-  eigen_conversions
-  moveit_core
-  moveit_ros_planning
-  pluginlib
-  roscpp
-  tf2
-  tf2_eigen
-  tf2_kdl
-  tf2_geometry_msgs
-)
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_kdl REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 find_package(OpenMP)
 # the specific flag is not yet present in cmake 2.8.12
@@ -63,20 +62,6 @@ else()
     set(CPPOPTLIB_INCLUDE_DIRS)
 endif()
 
-catkin_package(
-    INCLUDE_DIRS include
-    LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS
-        eigen_conversions
-        moveit_core
-        moveit_ros_planning
-        pluginlib
-        roscpp
-        tf2
-        tf2_kdl
-        tf2_geometry_msgs
-)
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options(-frecord-gcc-switches)
 endif()
@@ -89,14 +74,12 @@ include_directories(
     include
     ${FANN_INCLUDE_DIRS}
     ${CPPOPTLIB_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
 )
 
 set(SOURCES
     src/goal_types.cpp
     src/kinematics_plugin.cpp
     src/problem.cpp
-
     src/ik_test.cpp
     src/ik_gradient.cpp
     src/ik_evolution_1.cpp
@@ -113,12 +96,28 @@ endif()
 
 add_library(${PROJECT_NAME} ${SOURCES})
 
-set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
-add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+ament_target_dependencies(
+  ${PROJECT_NAME}
+  PUBLIC
+    Eigen3
+    moveit_core
+    moveit_ros_planning
+    pluginlib
+    rclcpp
+    tf2_eigen
+    tf2_ros
+    tf2_kdl
+    tf2_geometry_msgs
+)
 
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
+target_link_libraries(
+  ${PROJECT_NAME}
+  PUBLIC
   ${FANN_LIBRARIES}
   ${OpenMP_LIBS}
 
@@ -126,8 +125,63 @@ target_link_libraries(${PROJECT_NAME}
   -static-libstdc++
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+add_library(${PROJECT_NAME}_plugin SHARED
+  ${SOURCES}
+  src/kinematics_plugin.cpp
+)
 
-install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+target_include_directories(${PROJECT_NAME}_plugin PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
-install(FILES bio_ik_kinematics_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+target_link_libraries(
+  ${PROJECT_NAME}_plugin
+  PRIVATE
+    ${PROJECT_NAME}
+)
+
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+install(
+  TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_plugin
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+
+pluginlib_export_plugin_description_file(
+  moveit_core
+  bio_ik_kinematics_description.xml
+)
+
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  ${PROJECT_NAME}_plugin
+)
+ament_export_targets(
+  export_${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(bio_ik_test test/utest.cpp)
+  target_link_libraries(bio_ik_test
+    bio_ik
+  )
+  target_include_directories(bio_ik_test
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PUBLIC $<INSTALL_INTERFACE:include>)
+  
+endif()
+
+ament_package()

--- a/README.md
+++ b/README.md
@@ -14,20 +14,18 @@ in terms of success rate, precision and efficiency, and is actually usable for p
 
 ## Installation and Setup
 
-You will need ROS version Indigo or newer (wiki.ros.org).
-The software was developed on Ubuntu Linux 16.04 LTS with ROS Kinetic,
-but has also been tested on Ubuntu Linux 14.04 LTS with ROS Indigo.
-Newer versions of ROS should work, but may need some adaptation.
+You will need ROS 2 version Galactic or newer: [https://docs.ros.org/en/galactic/Installation.html](https://docs.ros.org/en/galactic/Installation.html).
+This version of the software was developed on Ubuntu Linux 20.04 LTS with ROS 2 Galactic.
+Newer versions of ROS 2 should work, but may need some adaptation.
 See below for version specific instructions.
 
-* Download the `bio_ik` package and unpack into your catkin workspace.
-* Run `catkin_make` to compile your workspace:
+* Download the `bio_ik` package and unpack into your colcon workspace.
+* Run `colcon build --mixin release` to compile your workspace:
   ```
-    roscd
-    cd src
-    git clone https://github.com/TAMS-Group/bio_ik.git
-    roscd
-    catkin_make
+    cd <PATH TO WORKSPACE>/src
+    git clone -b ros2 https://github.com/TAMS-Group/bio_ik.git
+    cd ..
+    colcon build --mixin release
   ```
 
 * Configure Moveit to use bio_ik as the kinematics solver (see next section).
@@ -107,24 +105,51 @@ or used interactively from rviz using the MotionPlanning GUI plugin.
   ```
 
 
-* For a first test, run the Moveit-created demo launch. Once rviz is running,
-  enable the motion planning plugin, then select one of the end effectors
-  of you robot. Rviz should show an 6-D (position and orientation)
-  interactive marker for the selected end-effector(s).
-  Move the interactive marker and watch bio_ik calculating poses for your robot.
+* For a first test, follow the [Quickstart in Rviz](https://moveit.picknik.ai/galactic/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html)
+  MoveIt2 tutorial. Before building your workspace, be sure to replace the kinematics solver for the Panda robot in
+  `<colcon workspace>/src/moveit_resources/panda_moveit_config/config/kinematics.yaml` as shown below:
 
-  If you also installed the bio_ik demo (see below), you should be able
-  to run one of the predefined demos:
+
+  ```yaml
+  panda_arm:
+    kinematics_solver: bio_ik/BioIKKinematicsPlugin
+    kinematics_solver_search_resolution: 0.005
+    kinematics_solver_timeout: 0.005
+    kinematics_solver_attempts: 1
   ```
-    roslaunch pr2_bioik_moveit demo.launch
-    roslaunch pr2_bioik_moveit valve.launch
-    roslaunch pr2_bioik_moveit dance.launch
+
+  To use a solver class besides the default `bio2_memetic`, the ROS param `mode` must be set to one
+  of the options [below](#disabling-global-optimization) (e.g. 'gd_c'). To do so for the Quickstart
+  in Rviz tutorial, edit the rviz node within `<colcon workspace>/src/moveit2_tutorials/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py` as such:
+
+  ```python
+  rviz_node_tutorial = Node(
+    package="rviz2",
+    executable="rviz2",
+    name="rviz2",
+    output="log",
+    arguments=["-d", rviz_empty_config],
+    parameters=[
+        robot_description,
+        robot_description_semantic,
+        ompl_planning_pipeline_config,
+        kinematics_yaml,
+        {"mode": "gd_c"} # use gd_c solver instead of default "bio2_memetic"
+    ],
+    condition=IfCondition(tutorial_mode),
+  )
   ```
+
+  Once you make this change, remember to rebuild your workspace.
+
+  After enabling the Motion Planning Plugin in Rviz, check the "Approx IK Solutions" box before attempting to move the arm.
+
 
 * You are now ready to use bio_ik from your C/C++ and Python programs,
   using the standard Moveit API.
   To explicitly request an IK solution in C++:
-  ```
+
+  ```c++
     robot_model_loader::RobotModelLoader robot_model_loader(robot);
 
     auto robot_model = robot_model_loader.getModel();
@@ -136,15 +161,16 @@ or used interactively from rviz using the MotionPlanning GUI plugin.
 
     robot_state::RobotState robot_state_ik(robot_model);
 
-    // traditional "basic" bio_ik usage. The end-effector goal poses
-    // and end-effector link names are passed into the setFromIK()
-    // call. The KinematicsQueryOptions are empty.
-    //
+    const geometry_msgs::msg::Pose pose;
+
+    // Several overloads for setFromIK are available
+    // here, we plass the joint model group, desired pose, and a timeout.
+    // We can leave the callback and options empty.
+    // Several desired poses can be passed with a separate overload
     bool ok = robot_state_ik.setFromIK(
                 joint_model_group, // joints to be used for IK
-                tip_transforms,    // multiple end-effector goal poses
-                tip_names,         // names of the end-effector links
-                attempts, timeout, // solver attempts and timeout
+                pose,    // end-effector goal pose
+                timeout, // solver attempts and timeout
                 moveit::core::GroupStateValidityCallbackFn(),
                 opts               // mostly empty
               );
@@ -239,7 +265,7 @@ All of this is specified easily:
     auto* torso_goal = new bio_ik::PositionGoal();
     torso_goal->setLinkName("torso_lift_link");
     torso_goal->setWeight(1);
-    torso_goal->setPosition(tf::Vector3( -0.05, 0, 1.0 ));
+    torso_goal->setPosition(tf2::Vector3( -0.05, 0, 1.0 ));
     ik_options.goals.emplace_back(torso_goal);
   ```
 
@@ -247,7 +273,7 @@ For the actual turning motion, we calculate a set of required gripper
 poses in a loop:
   ```
     for(int i = 0; ; i++) {
-        tf::Vector3 center(0.7, 0, 1);
+        tf2::Vector3 center(0.7, 0, 1);
 
         double t = i * 0.1;
         double r = 0.1;
@@ -256,9 +282,9 @@ poses in a loop:
         double dy = cos(a) * r;
         double dz = sin(a) * r;
 
-        tf::Vector3 dl(dx, +dy, +dz);
-        tf::Vector3 dr(dx, -dy, -dz);
-        tf::Vector3 dg = tf::Vector3(0, cos(a), sin(a)) * (0.025 + fmin(0.025, fmax(0.0, cos(t) * 0.1)));
+        tf2::Vector3 dl(dx, +dy, +dz);
+        tf2::Vector3 dr(dx, -dy, -dz);
+        tf2::Vector3 dg = tf2::Vector3(0, cos(a), sin(a)) * (0.025 + fmin(0.025, fmax(0.0, cos(t) * 0.1)));
 
         ll_goal->setPosition(center + dl + dg);
         lr_goal->setPosition(center + dl - dg);
@@ -266,12 +292,12 @@ poses in a loop:
         rr_goal->setPosition(center + dr - dg);
 
         double ro = 0;
-        ll_goal->setOrientation(tf::Quaternion(tf::Vector3(1, 0, 0), a + ro));
-        lr_goal->setOrientation(tf::Quaternion(tf::Vector3(1, 0, 0), a + ro));
-        rl_goal->setOrientation(tf::Quaternion(tf::Vector3(1, 0, 0), a + ro));
-        rr_goal->setOrientation(tf::Quaternion(tf::Vector3(1, 0, 0), a + ro));
+        ll_goal->setOrientation(tf2::Quaternion(tf2::Vector3(1, 0, 0), a + ro));
+        lr_goal->setOrientation(tf2::Quaternion(tf2::Vector3(1, 0, 0), a + ro));
+        rl_goal->setOrientation(tf2::Quaternion(tf2::Vector3(1, 0, 0), a + ro));
+        rr_goal->setOrientation(tf2::Quaternion(tf2::Vector3(1, 0, 0), a + ro));
 
-        lookat_goal->setAxis(tf::Vector3(1, 0, 0));
+        lookat_goal->setAxis(tf2::Vector3(1, 0, 0));
         lookat_goal->setTarget(rr_goal->getPosition());
 
         // "advanced" bio_ik usage. The call parameters for the end-effector
@@ -279,12 +305,12 @@ poses in a loop:
         // requested goals and weights are passed via the ik_options object.
         //
         robot_state.setFromIK(
-                      joint_model_group,           // active PR2 joints
-                      EigenSTL::vector_Affine3d(), // no explicit poses here
-                      std::vector<std::string>(),  // no end effector links here
-                      0, 0.0,                      // take values from YAML file
+                      joint_model_group,             // active PR2 joints
+                      EigenSTL::vector_Isometry3d(), // no explicit poses here
+                      std::vector<std::string>(),    // no end effector links here
+                      0.0,                           // take value from YAML file
                       moveit::core::GroupStateValidityCallbackFn(),
-                      ik_options       // four gripper goals and secondary goals
+                      ik_options                     // four gripper goals and secondary goals
                     );
 
         ... // check solution validity and actually move the robot

--- a/bio_ik_kinematics_description.xml
+++ b/bio_ik_kinematics_description.xml
@@ -1,4 +1,4 @@
-<library path="lib/libbio_ik">
+<library path="bio_ik_plugin">
     <class name="bio_ik/BioIKKinematicsPlugin" type="bio_ik_kinematics_plugin::BioIKKinematicsPlugin" base_class_type="kinematics::KinematicsBase">
     </class>
 </library>

--- a/include/bio_ik/frame.h
+++ b/include/bio_ik/frame.h
@@ -48,7 +48,7 @@ namespace bio_ik
 typedef tf2::Quaternion Quaternion;
 typedef tf2::Vector3 Vector3;
 
-struct Frame
+struct alignas(32) Frame
 {
     Vector3 pos;
     double __padding[4 - (sizeof(Vector3) / sizeof(double))];
@@ -66,7 +66,7 @@ struct Frame
         kdl.M.GetQuaternion(qx, qy, qz, qw);
         rot = tf2::Quaternion(qx, qy, qz, qw);
     }
-    explicit inline Frame(const geometry_msgs::Pose& msg)
+    explicit inline Frame(const geometry_msgs::msg::Pose& msg)
     {
         tf2::fromMsg(msg.orientation, rot);
         pos = tf2::Vector3(msg.position.x, msg.position.y, msg.position.z);

--- a/include/bio_ik/goal.h
+++ b/include/bio_ik/goal.h
@@ -120,7 +120,7 @@ public:
 
 struct BioIKKinematicsQueryOptions : kinematics::KinematicsQueryOptions
 {
-    std::vector<std::unique_ptr<Goal>> goals;
+    std::vector<std::shared_ptr<Goal>> goals;
     std::vector<std::string> fixed_joints;
     bool replace;
     mutable double solution_fitness;

--- a/package.xml
+++ b/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
 
     <name>bio_ik</name>
-    <version>1.0.0</version>
-    <description>BioIK for ROS</description>
+    <version>2.0.0</version>
+    <description>BioIK for ROS 2</description>
     <license>BSD</license>
 
     <author email="0ruppel@informatik.uni-hamburg.de">Philipp Sebastian Ruppel</author>
@@ -12,39 +12,22 @@
     <maintainer email="me@v4hn.de">Michael Goerner</maintainer>
 
 
-    <buildtool_depend>catkin</buildtool_depend>
+    <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-    <build_depend>moveit_core</build_depend>
-    <run_depend>moveit_core</run_depend>
+    <depend>moveit_core</depend>
+    <depend>pluginlib</depend>
+    <depend>eigen</depend>
+    <depend>moveit_ros_planning</depend>
+    <depend>rclcpp</depend>
+    <depend>tf2</depend>
+    <depend>tf2_eigen</depend>
+    <depend>tf2_kdl</depend>
+    <depend>tf2_geometry_msgs</depend>
 
-    <build_depend>pluginlib</build_depend>
-    <run_depend>pluginlib</run_depend>
-
-    <build_depend>eigen</build_depend>
-    <run_depend>eigen</run_depend>
-
-    <build_depend>moveit_ros_planning</build_depend>
-    <run_depend>moveit_ros_planning</run_depend>
-
-    <build_depend>roscpp</build_depend>
-    <run_depend>roscpp</run_depend>
-
-    <build_depend>tf2</build_depend>
-    <run_depend>tf2</run_depend>
-
-    <build_depend>tf2_eigen</build_depend>
-    <run_depend>tf2_eigen</run_depend>
-    <build_depend>tf2_kdl</build_depend>
-    <run_depend>tf2_kdl</run_depend>
-    <build_depend>tf2_geometry_msgs</build_depend>
-    <run_depend>tf2_geometry_msgs</run_depend>
-
-    <build_depend>eigen_conversions</build_depend>
-    <run_depend>eigen_conversions</run_depend>
-
-    <test_depend>rosunit</test_depend>
+    <test_depend>ament_cmake_gtest</test_depend>
 
     <export>
+        <build_type>ament_cmake</build_type>
         <moveit_core plugin="${prefix}/bio_ik_kinematics_description.xml"/>
     </export>
 

--- a/src/ik_parallel.h
+++ b/src/ik_parallel.h
@@ -97,7 +97,7 @@ struct IKParallel
     std::vector<double> solver_fitness;
     int thread_count;
     // std::vector<RobotFK_Fast> fk; // TODO: remove
-    double timeout;
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<double>> timeout;
     bool success;
     std::atomic<int> finished;
     std::atomic<uint32_t> iteration_count;
@@ -157,7 +157,7 @@ private:
         }
 
         // run solver iterations until solution found or timeout
-        for(size_t iteration = 0; (ros::WallTime::now().toSec() < timeout && finished == 0) || (iteration == 0 && i == 0); iteration++)
+        for(size_t iteration = 0; (std::chrono::system_clock::now() < timeout && finished == 0) || (iteration == 0 && i == 0); iteration++)
         {
             if(finished) break;
 
@@ -165,7 +165,7 @@ private:
             solvers[i]->step();
             iteration_count++;
             for(int it2 = 1; it2 < 4; it2++)
-                if(ros::WallTime::now().toSec() < timeout && finished == 0) solvers[i]->step();
+                if(std::chrono::system_clock::now() < timeout && finished == 0) solvers[i]->step();
 
             if(finished) break;
 

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -46,12 +46,12 @@
 #include <kdl_parser/kdl_parser.hpp>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/rdf_loader/rdf_loader.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <srdfdom/model.h>
 #include <urdf/model.h>
 #include <urdf_model/model.h>
 
-#include <eigen_conversions/eigen_msg.h>
+
 #include <tf2_eigen/tf2_eigen.h>
 //#include <moveit/common_planning_interface_objects/common_objects.h>
 #include <moveit/kinematics_base/kinematics_base.h>
@@ -106,17 +106,8 @@ toBioIKKinematicsQueryOptions(const void *ptr) {
 
 namespace bio_ik_kinematics_plugin {
 
-// Fallback for older MoveIt versions which don't support lookupParam yet
-template <class T>
-static void lookupParam(const std::string &param, T &val,
-                        const T &default_val) {
-  ros::NodeHandle nodeHandle("~");
-  val = nodeHandle.param(param, default_val);
-}
-
 struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
   std::vector<std::string> joint_names, link_names;
-  moveit::core::RobotModelConstPtr robot_model;
   const moveit::core::JointModelGroup *joint_model_group;
   mutable std::unique_ptr<IKParallel> ik;
   mutable std::vector<double> state, temp;
@@ -139,15 +130,15 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
   virtual bool getPositionFK(const std::vector<std::string> &link_names,
                              const std::vector<double> &joint_angles,
-                             std::vector<geometry_msgs::Pose> &poses) const {
+                             std::vector<geometry_msgs::msg::Pose> &poses) const {
     LOG_FNC();
     return false;
   }
 
-  virtual bool getPositionIK(const geometry_msgs::Pose &ik_pose,
+  virtual bool getPositionIK(const geometry_msgs::msg::Pose &ik_pose,
                              const std::vector<double> &ik_seed_state,
                              std::vector<double> &solution,
-                             moveit_msgs::MoveItErrorCodes &error_code,
+                             moveit_msgs::msg::MoveItErrorCodes &error_code,
                              const kinematics::KinematicsQueryOptions &options =
                                  kinematics::KinematicsQueryOptions()) const {
     LOG_FNC();
@@ -164,58 +155,23 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
   mutable Problem problem;
 
-  static moveit::core::RobotModelConstPtr
-  loadRobotModel(const std::string &robot_description) {
-    static std::map<std::string, moveit::core::RobotModelConstPtr>
-        robot_model_cache;
-    static std::mutex cache_mutex;
-    std::lock_guard<std::mutex> lock(cache_mutex);
-    if (robot_model_cache.find(robot_description) == robot_model_cache.end()) {
-      rdf_loader::RDFLoader rdf_loader(robot_description);
-      auto srdf = rdf_loader.getSRDF();
-      auto urdf_model = rdf_loader.getURDF();
-
-      if (!urdf_model || !srdf) {
-        LOG("URDF and SRDF must be loaded for kinematics solver to work.");
-        return nullptr;
-      }
-      robot_model_cache[robot_description] = moveit::core::RobotModelConstPtr(
-          new robot_model::RobotModel(urdf_model, srdf));
+  template <class T>
+  void getRosParam(const std::string &param, T &val, const T &default_val)
+  {
+    if (!node_->has_parameter(param))
+    {
+      val = node_->declare_parameter(param, rclcpp::ParameterValue{default_val}).get<T>();
+      return;
     }
-    return robot_model_cache[robot_description];
-
-    // return
-    // moveit::planning_interface::getSharedRobotModel(robot_description);
+    val = node_->get_parameter(param).get_value<T>();
   }
 
-  bool load(const moveit::core::RobotModelConstPtr &model,
-            std::string robot_description, std::string group_name) {
+  bool load(std::string group_name) {
     LOG_FNC();
 
-    // LOG_VAR(robot_description);
-    // LOG_VAR(group_name);
+    LOG("bio ik init", node_->getName());
 
-    LOG("bio ik init", ros::this_node::getName());
-
-    /*rdf_loader::RDFLoader rdf_loader(robot_description_);
-    auto srdf = rdf_loader.getSRDF();
-    auto urdf_model = rdf_loader.getURDF();
-
-    if(!urdf_model || !srdf)
-    {
-        LOG("URDF and SRDF must be loaded for kinematics solver to work.");
-        return false;
-    }
-
-    robot_model.reset(new robot_model::RobotModel(urdf_model, srdf));*/
-
-    if (model) {
-      this->robot_model = model;
-    } else {
-      this->robot_model = loadRobotModel(robot_description);
-    }
-
-    joint_model_group = robot_model->getJointModelGroup(group_name);
+    joint_model_group = robot_model_->getJointModelGroup(group_name);
     if (!joint_model_group) {
       LOG("failed to get joint model group");
       return false;
@@ -236,37 +192,34 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
     link_names = tip_frames_;
 
-    // for(auto& n : joint_names) LOG("joint", n);
-    // for(auto& n : link_names) LOG("link", n);
-
     // bool enable_profiler;
-    lookupParam("profiler", enable_profiler, false);
+    getRosParam("profiler", enable_profiler, false);
     // if(enable_profiler) Profiler::start();
 
-    robot_info = RobotInfo(robot_model);
+    robot_info = RobotInfo(robot_model_);
 
-    ikparams.robot_model = robot_model;
+    ikparams.robot_model = robot_model_;
     ikparams.joint_model_group = joint_model_group;
 
     // initialize parameters for IKParallel
-    lookupParam("mode", ikparams.solver_class_name,
+    getRosParam("mode", ikparams.solver_class_name,
                 std::string("bio2_memetic"));
-    lookupParam("counter", ikparams.enable_counter, false);
-    lookupParam("threads", ikparams.thread_count, 0);
-    lookupParam("random_seed", ikparams.random_seed, static_cast<int>(std::random_device()()));
+    getRosParam("counter", ikparams.enable_counter, false);
+    getRosParam("threads", ikparams.thread_count, 0);
+    getRosParam("random_seed", ikparams.random_seed, static_cast<int>(std::random_device()()));
 
     // initialize parameters for Problem
-    lookupParam("dpos", ikparams.dpos, DBL_MAX);
-    lookupParam("drot", ikparams.drot, DBL_MAX);
-    lookupParam("dtwist", ikparams.dtwist, 1e-5);
+    getRosParam("dpos", ikparams.dpos, DBL_MAX);
+    getRosParam("drot", ikparams.drot, DBL_MAX);
+    getRosParam("dtwist", ikparams.dtwist, 1e-5);
 
     // initialize parameters for ik_evolution_1
-    lookupParam("no_wipeout", ikparams.opt_no_wipeout, false);
-    lookupParam("population_size", ikparams.population_size, 8);
-    lookupParam("elite_count", ikparams.elite_count, 4);
-    lookupParam("linear_fitness", ikparams.linear_fitness, false);
+    getRosParam("no_wipeout", ikparams.opt_no_wipeout, false);
+    getRosParam("population_size", ikparams.population_size, 8);
+    getRosParam("elite_count", ikparams.elite_count, 4);
+    getRosParam("linear_fitness", ikparams.linear_fitness, false);
 
-    temp_state.reset(new moveit::core::RobotState(robot_model));
+    temp_state.reset(new moveit::core::RobotState(robot_model_));
 
     ik.reset(new IKParallel(ikparams));
 
@@ -285,10 +238,10 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
         double rotation_scale = 0.5;
 
-        lookupParam("rotation_scale", rotation_scale, rotation_scale);
+        getRosParam("rotation_scale", rotation_scale, rotation_scale);
 
         bool position_only_ik = false;
-        lookupParam("position_only_ik", position_only_ik, position_only_ik);
+        getRosParam("position_only_ik", position_only_ik, position_only_ik);
         if (position_only_ik)
           rotation_scale = 0;
 
@@ -299,7 +252,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
       {
         double weight = 0;
-        lookupParam("center_joints_weight", weight, weight);
+        getRosParam("center_joints_weight", weight, weight);
         if (weight > 0.0) {
           auto *center_joints_goal = new bio_ik::CenterJointsGoal();
           center_joints_goal->setWeight(weight);
@@ -309,7 +262,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
       {
         double weight = 0;
-        lookupParam("avoid_joint_limits_weight", weight, weight);
+        getRosParam("avoid_joint_limits_weight", weight, weight);
         if (weight > 0.0) {
           auto *avoid_joint_limits_goal = new bio_ik::AvoidJointLimitsGoal();
           avoid_joint_limits_goal->setWeight(weight);
@@ -319,7 +272,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
       {
         double weight = 0;
-        lookupParam("minimal_displacement_weight", weight, weight);
+        getRosParam("minimal_displacement_weight", weight, weight);
         if (weight > 0.0) {
           auto *minimal_displacement_goal =
               new bio_ik::MinimalDisplacementGoal();
@@ -334,97 +287,71 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
     return true;
   }
 
-  virtual bool initialize(const std::string &robot_description,
-                          const std::string &group_name,
-                          const std::string &base_frame,
-                          const std::string &tip_frame,
-                          double search_discretization) {
-    LOG_FNC();
-    std::vector<std::string> tip_frames;
-    tip_frames.push_back(tip_frame);
-    initialize(robot_description, group_name, base_frame, tip_frames,
-               search_discretization);
-    return true;
-  }
-
-  virtual bool initialize(const std::string &robot_description,
+  virtual bool initialize(const rclcpp::Node::SharedPtr &node,
+                          const moveit::core::RobotModel &robot_model,
                           const std::string &group_name,
                           const std::string &base_frame,
                           const std::vector<std::string> &tip_frames,
                           double search_discretization) {
     LOG_FNC();
-    setValues(robot_description, group_name, base_frame, tip_frames,
-              search_discretization);
-    load(moveit::core::RobotModelConstPtr(), robot_description, group_name);
-    return true;
-  }
-
-  virtual bool initialize(const moveit::core::RobotModel &robot_model,
-                          const std::string &group_name,
-                          const std::string &base_frame,
-                          const std::vector<std::string> &tip_frames,
-                          double search_discretization) {
-    LOG_FNC();
-    setValues("", group_name, base_frame, tip_frames, search_discretization);
-    load(moveit::core::RobotModelConstPtr(
-             (moveit::core::RobotModel *)&robot_model,
-             [](const moveit::core::RobotModel *robot_model) {}),
-         "", group_name);
-    return true;
+    node_ = node;
+    storeValues(robot_model, group_name, base_frame, tip_frames,
+                search_discretization);
+    return load(group_name);
   }
 
   virtual bool
-  searchPositionIK(const geometry_msgs::Pose &ik_pose,
+  searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
                    const std::vector<double> &ik_seed_state, double timeout,
                    std::vector<double> &solution,
-                   moveit_msgs::MoveItErrorCodes &error_code,
+                   moveit_msgs::msg::MoveItErrorCodes &error_code,
                    const kinematics::KinematicsQueryOptions &options =
                        kinematics::KinematicsQueryOptions()) const {
     LOG_FNC();
-    return searchPositionIK(std::vector<geometry_msgs::Pose>{ik_pose},
+    return searchPositionIK(std::vector<geometry_msgs::msg::Pose>{ik_pose},
                             ik_seed_state, timeout, std::vector<double>(),
                             solution, IKCallbackFn(), error_code, options);
   }
 
   virtual bool
-  searchPositionIK(const geometry_msgs::Pose &ik_pose,
+  searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
                    const std::vector<double> &ik_seed_state, double timeout,
                    const std::vector<double> &consistency_limits,
                    std::vector<double> &solution,
-                   moveit_msgs::MoveItErrorCodes &error_code,
+                   moveit_msgs::msg::MoveItErrorCodes &error_code,
                    const kinematics::KinematicsQueryOptions &options =
                        kinematics::KinematicsQueryOptions()) const {
     LOG_FNC();
-    return searchPositionIK(std::vector<geometry_msgs::Pose>{ik_pose},
+    return searchPositionIK(std::vector<geometry_msgs::msg::Pose>{ik_pose},
                             ik_seed_state, timeout, consistency_limits,
                             solution, IKCallbackFn(), error_code, options);
   }
 
   virtual bool
-  searchPositionIK(const geometry_msgs::Pose &ik_pose,
+  searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
                    const std::vector<double> &ik_seed_state, double timeout,
                    std::vector<double> &solution,
                    const IKCallbackFn &solution_callback,
-                   moveit_msgs::MoveItErrorCodes &error_code,
+                   moveit_msgs::msg::MoveItErrorCodes &error_code,
                    const kinematics::KinematicsQueryOptions &options =
                        kinematics::KinematicsQueryOptions()) const {
     LOG_FNC();
-    return searchPositionIK(std::vector<geometry_msgs::Pose>{ik_pose},
+    return searchPositionIK(std::vector<geometry_msgs::msg::Pose>{ik_pose},
                             ik_seed_state, timeout, std::vector<double>(),
                             solution, solution_callback, error_code, options);
   }
 
   virtual bool
-  searchPositionIK(const geometry_msgs::Pose &ik_pose,
+  searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
                    const std::vector<double> &ik_seed_state, double timeout,
                    const std::vector<double> &consistency_limits,
                    std::vector<double> &solution,
                    const IKCallbackFn &solution_callback,
-                   moveit_msgs::MoveItErrorCodes &error_code,
+                   moveit_msgs::msg::MoveItErrorCodes &error_code,
                    const kinematics::KinematicsQueryOptions &options =
                        kinematics::KinematicsQueryOptions()) const {
     LOG_FNC();
-    return searchPositionIK(std::vector<geometry_msgs::Pose>{ik_pose},
+    return searchPositionIK(std::vector<geometry_msgs::msg::Pose>{ik_pose},
                             ik_seed_state, timeout, consistency_limits,
                             solution, solution_callback, error_code, options);
   }
@@ -435,20 +362,16 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
   };*/
 
   virtual bool
-  searchPositionIK(const std::vector<geometry_msgs::Pose> &ik_poses,
+  searchPositionIK(const std::vector<geometry_msgs::msg::Pose> &ik_poses,
                    const std::vector<double> &ik_seed_state, double timeout,
                    const std::vector<double> &consistency_limits,
                    std::vector<double> &solution,
                    const IKCallbackFn &solution_callback,
-                   moveit_msgs::MoveItErrorCodes &error_code,
+                   moveit_msgs::msg::MoveItErrorCodes &error_code,
                    const kinematics::KinematicsQueryOptions &options =
                        kinematics::KinematicsQueryOptions(),
                    const moveit::core::RobotState *context_state = NULL) const {
-    double t0 = ros::WallTime::now().toSec();
-
-    // timeout = 0.1;
-
-    // LOG("a");
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<double>> t0 = std::chrono::system_clock::now();
 
     if (enable_profiler)
       Profiler::start();
@@ -459,23 +382,20 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
     FNPROFILER();
 
-    // LOG(typeid(options).name());
-    // LOG(((OptMod*)&options)->test);
-
     // get variable default positions / context state
-    state.resize(robot_model->getVariableCount());
+    state.resize(robot_model_->getVariableCount());
     if (context_state)
-      for (size_t i = 0; i < robot_model->getVariableCount(); i++)
+      for (size_t i = 0; i < robot_model_->getVariableCount(); i++)
         state[i] = context_state->getVariablePositions()[i];
     else
-      robot_model->getVariableDefaultPositions(state);
+      robot_model_->getVariableDefaultPositions(state);
 
     // overwrite used variables with seed state
     solution = ik_seed_state;
     {
       int i = 0;
       for (auto &joint_name : getJointNames()) {
-        auto *joint_model = robot_model->getJointModel(joint_name);
+        auto *joint_model = robot_model_->getJointModel(joint_name);
         if (!joint_model)
           continue;
         for (size_t vi = 0; vi < joint_model->getVariableCount(); vi++)
@@ -489,7 +409,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
       tipFrames.clear();
       for (size_t i = 0; i < ik_poses.size(); i++) {
         Eigen::Isometry3d p, r;
-        tf::poseMsgToEigen(ik_poses[i], p);
+        tf2::fromMsg(ik_poses[i], p);
         if (context_state) {
           r = context_state->getGlobalLinkTransform(getBaseFrame());
         } else {
@@ -503,7 +423,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
 
     // init ik
 
-    problem.timeout = t0 + timeout;
+    problem.timeout = t0 + std::chrono::duration<double>(timeout);
     problem.initial_guess = state;
 
     // for(auto& v : state) LOG("var", &v - &state.front(), v);
@@ -581,7 +501,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
     for (auto ivar : problem.active_variables) {
       auto v = state[ivar];
       if (robot_info.isRevolute(ivar) &&
-          robot_model->getMimicJointModels().empty()) {
+          robot_model_->getMimicJointModels().empty()) {
         auto r = problem.initial_guess[ivar];
         auto lo = robot_info.getMin(ivar);
         auto hi = robot_info.getMax(ivar);
@@ -613,13 +533,13 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
     }
 
     // wrap angles
-    robot_model->enforcePositionBounds(state.data());
+    robot_model_->enforcePositionBounds(state.data());
 
     // map result to jointgroup variables
     {
       solution.clear();
       for (auto &joint_name : getJointNames()) {
-        auto *joint_model = robot_model->getJointModel(joint_name);
+        auto *joint_model = robot_model_->getJointModel(joint_name);
         if (!joint_model)
           continue;
         for (size_t vi = 0; vi < joint_model->getVariableCount(); vi++)

--- a/src/problem.h
+++ b/src/problem.h
@@ -128,7 +128,7 @@ public:
         Frame frame;
         GoalContext goal_context;
     };
-    double timeout;
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<double>> timeout;
     std::vector<double> initial_guess;
     std::vector<size_t> active_variables;
     std::vector<size_t> tip_link_indices;

--- a/src/utils.h
+++ b/src/utils.h
@@ -37,8 +37,6 @@
 #include <csignal>
 #include <iostream>
 
-#include <ros/ros.h>
-
 #include <atomic>
 #include <mutex>
 #include <thread>
@@ -49,14 +47,11 @@
 #include <malloc.h>
 #include <stdlib.h>
 
-#include <tf_conversions/tf_kdl.h>
-
-#include <XmlRpcException.h>
-
 //#include <link.h>
 
 //#include <boost/align/aligned_allocator.hpp>
 //#include <Eigen/Eigen>
+#include <moveit/robot_model/robot_model.h>
 
 namespace bio_ik
 {
@@ -469,56 +464,5 @@ template <class T, size_t A> struct aligned_allocator : public std::allocator<T>
 // std::vector typedef with proper memory alignment for SIMD operations
 template <class T> struct aligned_vector : std::vector<T, aligned_allocator<T, 32>>
 {
-};
-
-// Helper class for reading structured data from ROS parameter server
-class XmlRpcReader
-{
-    typedef XmlRpc::XmlRpcValue var;
-    var& v;
-
-public:
-    XmlRpcReader(var& v)
-        : v(v)
-    {
-    }
-
-private:
-    XmlRpcReader at(int i) { return v[i]; }
-    void conv(bool& r) { r = (bool)v; }
-    void conv(double& r) { r = (v.getType() == var::TypeInt) ? ((double)(int)v) : ((double)v); }
-    void conv(tf2::Vector3& r)
-    {
-        double x, y, z;
-        at(0).conv(x);
-        at(1).conv(y);
-        at(2).conv(z);
-        r = tf2::Vector3(x, y, z);
-    }
-    void conv(tf2::Quaternion& r)
-    {
-        double x, y, z, w;
-        at(0).conv(x);
-        at(1).conv(y);
-        at(2).conv(z);
-        at(3).conv(w);
-        r = tf2::Quaternion(x, y, z, w).normalized();
-    }
-    void conv(std::string& r) { r = (std::string)v; }
-
-public:
-    template <class T> void param(const char* key, T& r)
-    {
-        if(!v.hasMember(key)) return;
-        try
-        {
-            XmlRpcReader(v[key]).conv(r);
-        }
-        catch(const XmlRpc::XmlRpcException& e)
-        {
-            LOG(key);
-            throw;
-        }
-    }
 };
 }

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -35,9 +35,10 @@
 // BioIK unit tests
 
 #include <gtest/gtest.h>
+#include <random>
 
 #include "../src/utils.h"
-#include "../src/frame.h"
+#include <bio_ik/frame.h>
 
 using namespace bio_ik;
 


### PR DESCRIPTION
This is a minor change, but until #2 is merged the diff will show otherwise.

In order to properly use `bio_ik` as a kinematics plugin within MoveIt Task Constructor, `BioIKKinematicsQueryOptions` must be copyable. This PR enables that functionality without writing a custom copy constructor. This can also probably wait until https://github.com/ros-planning/moveit_task_constructor/pull/370 is merged.