### PR TITLE
Make BioIKKinematicsQueryOptions copyable

### DIFF
--- a/include/bio_ik/goal.h
+++ b/include/bio_ik/goal.h
@@ -120,7 +120,7 @@ public:
 
 struct BioIKKinematicsQueryOptions : kinematics::KinematicsQueryOptions
 {
-    std::vector<std::unique_ptr<Goal>> goals;
+    std::vector<std::shared_ptr<Goal>> goals;
     std::vector<std::string> fixed_joints;
     bool replace;
     mutable double solution_fitness;


### PR DESCRIPTION
In order to integrate bio_ik with MoveIt Task Constructor, BioIKKinematicsQueryOptions must be copy-constructable. Changing vector of goals to be `shared_ptr`'s instead of `unique_ptr`'s accomplishes this without having to write a custom copy ctor.