### PR TITLE
Fix severe warning in ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ include_directories(
 
 set(SOURCES
     src/goal_types.cpp
-    src/kinematics_plugin.cpp
     src/problem.cpp
     src/ik_test.cpp
     src/ik_gradient.cpp


### PR DESCRIPTION
Currently, kinematics_plugin.cpp is included in the bio_ik library and the bio_ik_plugin library which makes them identical and results in a severe warning by the class loader because the plugin is registered twice. Instead, kinematics_plugin.cpp should not be included when the library is built.