### PR TITLE
[ros2] Fix derived searchPositionIK function definition

### DIFF
--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -363,10 +363,11 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
       int test;
   };*/
 
-  bool
+  virtual bool
   searchPositionIK(const std::vector<geometry_msgs::msg::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
                    double timeout, const std::vector<double>& consistency_limits, std::vector<double>& solution,
-                   const IKCallbackFn& solution_callback, IKCostFn cost_function, moveit_msgs::msg::MoveItErrorCodes& error_code,
+                   const IKCallbackFn& solution_callback, const IKCostFn& cost_function,
+                   moveit_msgs::msg::MoveItErrorCodes& error_code,
                    const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions(),
                    const moveit::core::RobotState* context_state = nullptr) const override
   {


### PR DESCRIPTION
I was getting the following compilation error about the`searchPositionIK` function below saying its suppose to override the one in `kinematics::KinematicsBase` but it's not. Turns out that the function defintion was ever-so-slightly different from the base class version. This PR fixes it.

```
bio_ik/src/kinematics_plugin.cpp:367:3: error: ‘bool bio_ik_kinematics_plugin::BioIKKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::msg::Pose_<std::allocator<void> > >&, const std::vector<double, std::allocator<double> >&, double, const std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, const IKCallbackFn&, kinematics::KinematicsBase::IKCostFn, moveit_msgs::msg::MoveItErrorCodes&, const kinematics::KinematicsQueryOptions&, const moveit::core::RobotState*) const’ marked ‘override’, but does not override
  367 |   searchPositionIK(const std::vector<geometry_msgs::msg::Pose>& ik_poses, const std::vector<double>& ik_seed_state,
      |   ^~~~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/bio_ik_plugin.dir/build.make:160: CMakeFiles/bio_ik_plugin.dir/src/kinematics_plugin.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:185: CMakeFiles/bio_ik_plugin.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< bio_ik [11.3s, exited with code 2]
``