### PR TITLE
Do not link libgcc and stdc++ statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,6 @@ target_link_libraries(
   PUBLIC
   ${FANN_LIBRARIES}
   ${OpenMP_LIBS}
-
-  -static-libgcc
-  -static-libstdc++
 )
 
 add_library(${PROJECT_NAME}_plugin SHARED


### PR DESCRIPTION
Currently, `libgcc` and `libstdc++` are linked statically. This was added in 7cc7c10bd22cde4143b68f4ad1291e37c2482bd1 six years ago and I don't understand why it is necessary or even helpful. For me, it now breaks stuff when bio_ik is called in a python module. You can see the code [here](https://github.com/bit-bots/bitbots_motion/tree/master/bitbots_moveit_bindings). The errors that occur with the static linking are 
```
python: Relink `/home/timon/colcon_ws/install/bio_ik/lib/libbio_ik.so' with `/home/timon/colcon_ws/install/bio_ik/lib/libbio_ik_plugin.so' for IFUNC symbol `_Z98_ZNK6bio_ik15RobotFK_Mutator27computeApproximateMutation1EmdRKNS_14aligned_vectorINS_5FrameEEERS3_PKN6bio_ik15RobotFK_MutatorEmdRKNS_14aligned_vectorINS_5FrameEEERS5_'
python: Relink `/home/timon/colcon_ws/install/bio_ik/lib/libbio_ik.so' with `/home/timon/colcon_ws/install/bio_ik/lib/libbio_ik_plugin.so' for IFUNC symbol `_Z115_ZNK6bio_ik15RobotFK_Mutator27computeApproximateMutationsEmPKPKdRSt6vectorINS_14aligned_vectorINS_5FrameEEESaIS8_EEPKN6bio_ik15RobotFK_MutatorEmPKPKdRSt6vectorINS_14aligned_vectorINS_5FrameEEESaISA_EE'
free(): invalid pointer
[1]    758239 IOT instruction  python script.py
```
With this patch applied, everything works as expected without any warnings or errors.