### PR TITLE
Make the parameters of bio2 configurable

### DIFF
--- a/src/ik_evolution_2.cpp
+++ b/src/ik_evolution_2.cpp
@@ -271,9 +271,14 @@ template <int memetic> struct IKEvolution2 : IKBase
         for(size_t child_index = population.size(); child_index < children.size(); child_index++)
         {
             double mutation_rate = (1 << fast_random_index(16)) * (1.0 / (1 << 23));
-            // todo(timon): this is using fixed parents
-            auto& parent = population[0];
-            auto& parent2 = population[1];
+            // randomly select distinct parents and make parent2 the larger index
+            // this is done to ensure that the same behavior is done as before when population size is 2
+            size_t p1, p2;
+            p1 = fast_random_index(population.size());
+            do { p2 = fast_random_index(population.size()); } while (p1 != p2);
+            if (p1 > p2) std::swap(p1, p2);
+            auto& parent = population[p1];
+            auto& parent2 = population[p2];
             double fmix = (child_index % 2 == 0) * 0.2;
             double gradient_factor = child_index % 3;
 

--- a/src/ik_evolution_2.cpp
+++ b/src/ik_evolution_2.cpp
@@ -71,10 +71,13 @@ template <int memetic> struct IKEvolution2 : IKBase
     std::vector<size_t> quaternion_genes;
     aligned_vector<double> genes_min, genes_max, genes_span;
     aligned_vector<double> gradient, temp;
+    size_t memetic_evolution_gens, evolution_gens, memetic_opt_gens;
+    size_t population_size, child_count, species_count;
 
     IKEvolution2(const IKParams& p)
         : IKBase(p)
     {
+        setParams(p);
     }
 
 #ifdef ENABLE_CPP_OPTLIB
@@ -108,6 +111,14 @@ template <int memetic> struct IKEvolution2 : IKBase
 
     const std::vector<double>& getSolution() const { return solution; }
 
+    void setParams(const IKParams& p) override {
+        population_size = p.population_size2;
+        child_count = p.child_count;
+        species_count = p.species_count;
+        memetic_opt_gens = p.memetic_opt_gens;
+        memetic_evolution_gens = p.memetic_evolution_gens;
+    }
+
     void initialize(const Problem& problem)
     {
         BLOCKPROFILER("initialization");
@@ -133,12 +144,8 @@ template <int memetic> struct IKEvolution2 : IKBase
         // init temporary buffer with positions of inactive joints
         temp_joint_variables = initial_guess;
 
-        // params
-        size_t population_size = 2;
-        size_t child_count = 16;
-
         // initialize population on current island
-        species.resize(2);
+        species.resize(species_count);
         for(auto& s : species)
         {
             // create individuals
@@ -347,7 +354,7 @@ template <int memetic> struct IKEvolution2 : IKBase
 
                 // run evolution for a few generations
                 size_t generation_count = 16;
-                if(memetic) generation_count = 8;
+                if(memetic) generation_count = memetic_evolution_gens;
                 for(size_t generation = 0; generation < generation_count; generation++)
                 {
                     // BLOCKPROFILER("evolution");
@@ -450,7 +457,7 @@ template <int memetic> struct IKEvolution2 : IKBase
                     double dp = 0.0000001;
                     if(fast_random() < 0.5) dp = -dp;
 
-                    for(size_t generation = 0; generation < 8; generation++)
+                    for(size_t generation = 0; generation < memetic_opt_gens; generation++)
                     // for(size_t generation = 0; generation < 32; generation++)
                     {
 

--- a/src/ik_evolution_2.cpp
+++ b/src/ik_evolution_2.cpp
@@ -259,10 +259,10 @@ template <int memetic> struct IKEvolution2 : IKBase
 
         auto gene_count = children[0].genes.size();
 
-        size_t s = (children.size() - population.size()) * gene_count + children.size() * 4 + 4;
+        size_t s = (children.size() - population.size()) * gene_count + children.size() * 32 + 32;
 
         auto* __restrict__ rr = fast_random_gauss_n(s);
-        rr = (const double*)(((size_t)rr + 3) / 4 * 4);
+        rr = (const double*)(((size_t)rr + 31) / 32 * 32);
 
         /*rmask.resize(s);
         for(auto& m : rmask) m = fast_random() < 0.1 ? 1.0 : 0.0;
@@ -293,7 +293,7 @@ template <int memetic> struct IKEvolution2 : IKBase
             auto __attribute__((aligned(32)))* __restrict__ child_genes = child.genes.data();
             auto __attribute__((aligned(32)))* __restrict__ child_gradients = child.gradients.data();
 
-#pragma omp simd aligned(genes_span : 32), aligned(genes_min : 32), aligned(genes_max : 32), aligned(parent_genes : 32), aligned(parent_gradients : 32), aligned(parent2_genes : 32), aligned(parent2_gradients : 32), aligned(child_genes : 32), aligned(child_gradients : 32) aligned(rr : 32)
+#pragma omp simd aligned(genes_span : 32), aligned(genes_min : 32), aligned(genes_max : 32), aligned(parent_genes : 32), aligned(parent_gradients : 32), aligned(parent2_genes : 32), aligned(parent2_gradients : 32), aligned(child_genes : 32), aligned(child_gradients : 32), aligned(rr : 32)
 #pragma unroll
             for(size_t gene_index = 0; gene_index < gene_count; gene_index++)
             {
@@ -312,7 +312,7 @@ template <int memetic> struct IKEvolution2 : IKBase
                 child_genes[gene_index] = gene;
                 child_gradients[gene_index] = mix(parent_gradient, gene - parent_gene, 0.3);
             }
-            rr += (gene_count + 3) / 4 * 4;
+            rr += (gene_count + 31) / 32 * 32;
             // dm += (gene_count + 3) / 4 * 4;
 
             /*if(problem.tip_link_indices.size() > 1)

--- a/src/ik_evolution_2.cpp
+++ b/src/ik_evolution_2.cpp
@@ -275,7 +275,7 @@ template <int memetic> struct IKEvolution2 : IKBase
             // this is done to ensure that the same behavior is done as before when population size is 2
             size_t p1, p2;
             p1 = fast_random_index(population.size());
-            do { p2 = fast_random_index(population.size()); } while (p1 != p2);
+            do { p2 = fast_random_index(population.size()); } while (p1 == p2 && population.size() > 1);
             if (p1 > p2) std::swap(p1, p2);
             auto& parent = population[p1];
             auto& parent2 = population[p2];

--- a/src/ik_evolution_2.cpp
+++ b/src/ik_evolution_2.cpp
@@ -112,12 +112,12 @@ template <int memetic> struct IKEvolution2 : IKBase
     const std::vector<double>& getSolution() const { return solution; }
 
     void setParams(const IKParams& p) override {
-        population_size = p.population_size2;
+        population_size = p.population_size;
         child_count = p.child_count;
         species_count = p.species_count;
         memetic_opt_gens = p.memetic_opt_gens;
         memetic_evolution_gens = p.memetic_evolution_gens;
-        elite_count = std::min(p.elite_count2, p.population_size2);
+        elite_count = std::min(p.elite_count, p.population_size);
     }
 
     void initialize(const Problem& problem)

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -215,19 +215,22 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
     getRosParam("drot", ikparams.drot, DBL_MAX);
     getRosParam("dtwist", ikparams.dtwist, 1e-5);
 
-    // initialize parameters for ik_evolution_1
-    getRosParam("no_wipeout", ikparams.opt_no_wipeout, false);
-    getRosParam("population_size", ikparams.population_size, 8);
-    getRosParam("elite_count", ikparams.elite_count, 4);
-    getRosParam("linear_fitness", ikparams.linear_fitness, false);
-
-    // parameters for bio2
-    getRosParam("population_size2", ikparams.population_size2, 2);
-    getRosParam("child_count", ikparams.child_count, 16);
-    getRosParam("species_count", ikparams.species_count, 2);
-    getRosParam("memetic_evolution_gens", ikparams.memetic_evolution_gens, 8);
-    getRosParam("memetic_opt_gens", ikparams.memetic_opt_gens, 8);
-    getRosParam("elite_count2", ikparams.elite_count2, 1);
+    if (ikparams.solver_class_name == "bio1")
+    {
+        // initialize parameters for ik_evolution_1
+        getRosParam("no_wipeout", ikparams.opt_no_wipeout, false);
+        getRosParam("population_size", ikparams.population_size, 8);
+        getRosParam("elite_count", ikparams.elite_count, 4);
+        getRosParam("linear_fitness", ikparams.linear_fitness, false);
+    } else {
+        // parameters for bio2
+        getRosParam("population_size", ikparams.population_size, 2);
+        getRosParam("child_count", ikparams.child_count, 16);
+        getRosParam("species_count", ikparams.species_count, 2);
+        getRosParam("memetic_evolution_gens", ikparams.memetic_evolution_gens, 8);
+        getRosParam("memetic_opt_gens", ikparams.memetic_opt_gens, 8);
+        getRosParam("elite_count", ikparams.elite_count, 1);
+    }
 
     temp_state.reset(new moveit::core::RobotState(robot_model_));
 

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -227,6 +227,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
     getRosParam("species_count", ikparams.species_count, 2);
     getRosParam("memetic_evolution_gens", ikparams.memetic_evolution_gens, 8);
     getRosParam("memetic_opt_gens", ikparams.memetic_opt_gens, 8);
+    getRosParam("elite_count2", ikparams.elite_count2, 1);
 
     temp_state.reset(new moveit::core::RobotState(robot_model_));
 

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -221,6 +221,13 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
     getRosParam("elite_count", ikparams.elite_count, 4);
     getRosParam("linear_fitness", ikparams.linear_fitness, false);
 
+    // parameters for bio2
+    getRosParam("population_size2", ikparams.population_size2, 2);
+    getRosParam("child_count", ikparams.child_count, 16);
+    getRosParam("species_count", ikparams.species_count, 2);
+    getRosParam("memetic_evolution_gens", ikparams.memetic_evolution_gens, 8);
+    getRosParam("memetic_opt_gens", ikparams.memetic_opt_gens, 8);
+
     temp_state.reset(new moveit::core::RobotState(robot_model_));
 
     ik.reset(new IKParallel(ikparams));

--- a/src/utils.h
+++ b/src/utils.h
@@ -72,19 +72,19 @@ struct IKParams
     double drot;
     double dtwist;
 
-    // ik_evolution_1 parameters
-    bool opt_no_wipeout;
+    // common parameters
     int population_size;
     int elite_count;
+
+    // ik_evolution_1 parameters
+    bool opt_no_wipeout;
     bool linear_fitness;
 
     // bio2 parameters
-    int population_size2;
     int child_count;
     int species_count;
     int memetic_evolution_gens;
     int memetic_opt_gens;
-    int elite_count2;
 };
 
 // Uncomment to enable logging

--- a/src/utils.h
+++ b/src/utils.h
@@ -77,6 +77,13 @@ struct IKParams
     int population_size;
     int elite_count;
     bool linear_fitness;
+
+    // bio2 parameters
+    int population_size2;
+    int child_count;
+    int species_count;
+    int memetic_evolution_gens;
+    int memetic_opt_gens;
 };
 
 // Uncomment to enable logging

--- a/src/utils.h
+++ b/src/utils.h
@@ -84,6 +84,7 @@ struct IKParams
     int species_count;
     int memetic_evolution_gens;
     int memetic_opt_gens;
+    int elite_count2;
 };
 
 // Uncomment to enable logging


### PR DESCRIPTION
This PR makes the parameters of the bio2 solver configurable as ROS parameters.
The available parameters are:
- `population_size`: number of possible parents
- `child_count`: Number of children
- `elite_count`: Number of elites (individuals that are further optimized)
- `threads`: Number of parallel threads
- `species_count`: Number of populations per thread
- `memetic_evolution_gens`: Number of iterations for evolution
- `memetic_opt_gens`: Number of iterations for optimization